### PR TITLE
Fixed some typos and broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Book 4: [The Genomics Module](genomics/README.md), working with genomic data.
 
 Book 5: [The Protein-Disorder Module](protein-disorder/README.md), predicting protein-disorder.
 
-Book 6: [The ModFinder Module](modfinder/README.md), identifying potein modifications in 3D structures
+Book 6: [The ModFinder Module](modfinder/README.md), identifying protein modifications in 3D structures
 
 ## License
 

--- a/structure/bioassembly.md
+++ b/structure/bioassembly.md
@@ -153,7 +153,7 @@ List<Structure> bioAssemblies = StructureIO.getBiologicalAssemblies(pdbId);
 
 ## Further Reading
 
-The RCSB PDB web site has a great [tutorial on Biological Assemblies](http://www.rcsb.org/pdb/101/static101.do?p=education_discussion/Looking-at-Structures/bioassembly_tutorial.html).
+The RCSB PDB web site has a great [tutorial on Biological Assemblies](https://pdb101.rcsb.org/learn/guide-to-understanding-pdb-data/biological-assemblies).
 
 <!--automatically generated footer-->
 

--- a/structure/secstruc.md
+++ b/structure/secstruc.md
@@ -10,8 +10,8 @@ Secondary structure can be formally defined by the pattern of hydrogen bonds of 
 More specifically, the secondary structure is defined by the patterns of hydrogen bonds formed between 
 amine hydrogen (-NH) and carbonyl oxygen (C=O) atoms contained in the backbone peptide bonds of the protein. 
 
-For more info see the Wikipedia article on [protein secondary structure]
-(https://en.wikipedia.org/wiki/Protein_secondary_structure).
+For more info see the Wikipedia article 
+on [protein secondary structure](https://en.wikipedia.org/wiki/Protein_secondary_structure).
 
 ## Secondary Structure Annotation
 
@@ -106,8 +106,8 @@ input Structure overriding any previous annotation, like in the DSSPParser. An e
     ssp.calculate(s, true); //true assigns the SS to the Structure
 ```
 
-BioJava Class: [org.biojava.nbio.structure.secstruc.SecStrucCalc]
-(http://www.biojava.org/docs/api/org/biojava/nbio/structure/secstruc/SecStrucCalc.html)
+BioJava Class: 
+[org.biojava.nbio.structure.secstruc.SecStrucCalc](http://www.biojava.org/docs/api/org/biojava/nbio/structure/secstruc/SecStrucCalc.html)
 
 ### Storage and Data Structures
 


### PR DESCRIPTION
One of the links to rcdb was a 404.  I think I got the correct replacement.   One typo, and a couple of internal link fixes.  The [...] and (...) can't have any whitespace.